### PR TITLE
Issue #18: Move .vue files to components dir

### DIFF
--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -5,7 +5,7 @@
   </div>
 </template>
 
-<script src="./index.js" />
+<script src="./Index/index.js" />
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped src="./index.css" />
+<style scoped src="./Index/index.css" />

--- a/src/components/Sessions.vue
+++ b/src/components/Sessions.vue
@@ -30,6 +30,6 @@
   </div>
 </template>
 
-<script src="./sessions.js"/>
+<script src="./Sessions/sessions.js"/>
 
-<style scoped type="text/css" src="./sessions.css"/>
+<style scoped type="text/css" src="./Sessions/sessions.css"/>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
-import Index from '@/components/Index/Index'
-import Sessions from '@/components/Sessions/Sessions'
+import Index from '@/components/Index'
+import Sessions from '@/components/Sessions'
 
 Vue.use(Router)
 


### PR DESCRIPTION
Rendering .vue under sub-directories of components folder doesn't
work on MacOS. Move .vue files to components dir and adjust router.

it fixes #18.