### PR TITLE
Issue #22 - Changing column name of session id

### DIFF
--- a/src/db/firebaseDB/index.js
+++ b/src/db/firebaseDB/index.js
@@ -9,7 +9,7 @@ firestore.settings(settings)
 
 const dbInfo = {
   NOTES_COLLECTION: 'notes',
-  SESSION_ID_FIELD: 'sessionId'
+  SESSION_ID_FIELD: 'session_id'
 }
 
 module.exports = function () {


### PR DESCRIPTION
Removed the Camel Case pattern of the session id field. Now using
Underscore Case.

It fixes #22.