### PR TITLE
Issue #31: Ordering notes by author

### DIFF
--- a/src/components/Sessions.vue
+++ b/src/components/Sessions.vue
@@ -19,7 +19,7 @@
           @click.native="filter_topic(key)"
           v-if="filter_name == null || filter_name == key">
             <note
-              v-for="note in notes"
+              v-for="note in sorted_notes(notes)"
               v-bind:note="note"
               v-bind:key="note.id"/>
         </topic>

--- a/src/components/Sessions/sessions.js
+++ b/src/components/Sessions/sessions.js
@@ -37,6 +37,16 @@ export default {
         this.filter_name = topic
         this.custom_class = 'div-topic-row'
       }
+    },
+    sorted_notes (notes) {
+      return notes.slice().sort((left, right) => {
+        if (left.user.toLowerCase() < right.user.toLowerCase()) {
+          return -1
+        } else if (left.user.toLowerCase() > right.user.toLowerCase()) {
+          return 1
+        }
+        return 0
+      })
     }
   },
   components: {


### PR DESCRIPTION
Now the notes are being ordered alphabetically by the author's
name.

It fixes #31.