### PR TITLE
Remove docker_layer_caching from circle ci config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,7 @@ jobs:
       - run: 
           name: Setup Google Cloud SDK
           command: scripts/setup.sh
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run: 
           name: Docker Build, Push and Deploy
           command: scripts/deploy.sh


### PR DESCRIPTION
Docker Layer Caching is only available on the Performance usage plan.